### PR TITLE
Added support for 16xN and 20xN screens

### DIFF
--- a/lcd_lib/lcd.c
+++ b/lcd_lib/lcd.c
@@ -7,7 +7,8 @@
 
 #include "lcd.h"
 
-
+const uint8_t ROW_16[] = {0x00, 0x40, 0x10, 0x50};
+const uint8_t ROW_20[] = {0x00, 0x40, 0x14, 0x54};
 /************************************** Static declarations **************************************/
 
 static void lcd_write_data(Lcd_HandleTypeDef * lcd, uint8_t data);
@@ -90,7 +91,20 @@ void Lcd_string(Lcd_HandleTypeDef * lcd, char * string)
  */
 void Lcd_cursor(Lcd_HandleTypeDef * lcd, uint8_t row, uint8_t col)
 {
-	lcd_write_command(lcd, SET_DDRAM_ADDR | ((row * 0x40) + col));
+	#ifdef LCD20xN
+	lcd_write_command(lcd, SET_DDRAM_ADDR + ROW_20[row] + col);
+	#endif
+
+	#ifdef LCD16xN
+	lcd_write_command(lcd, SET_DDRAM_ADDR + ROW_16[row] + col);
+	#endif
+}
+
+/**
+ * Clear the screen
+ */
+void Lcd_clear(Lcd_HandleTypeDef * lcd) {
+	lcd_write_command(lcd, CLEAR_DISPLAY);
 }
 
 

--- a/lcd_lib/lcd.h
+++ b/lcd_lib/lcd.h
@@ -12,6 +12,12 @@
 #include "string.h"
 #include "main.h"
 
+// #define LCD20xN 		// For 20xN LCDs
+#define LCD16xN			// For 16xN LCDs
+
+// For row start addresses
+extern const uint8_t ROW_16[];
+extern const uint8_t ROW_20[];
 
 /************************************** Command register **************************************/
 #define CLEAR_DISPLAY 0x01

--- a/readme.md
+++ b/readme.md
@@ -10,10 +10,12 @@ Features:
 - String printing
 - Number printing
 - Set cursor position
-
+- Clear screen
 
 ## 8bit example
 ```c
+#define LCD16xN // For 16xN screens
+
 Lcd_PortType ports[] = {
 	D0_GPIO_Port, D1_GPIO_Port, D2_GPIO_Port, D3_GPIO_Port,
 	D4_GPIO_Port, D5_GPIO_Port, D6_GPIO_Port, D7_GPIO_Port
@@ -33,6 +35,8 @@ Lcd_int(&lcd, -500);
 
 ## 4bit example
 ```c
+#define LCD20xN // For 20xN screens
+
 Lcd_PortType ports[] = {
 	D4_GPIO_Port, D5_GPIO_Port, D6_GPIO_Port, D7_GPIO_Port
 };

--- a/readme.md
+++ b/readme.md
@@ -12,10 +12,16 @@ Features:
 - Set cursor position
 - Clear screen
 
+## Using 16xN and 20xN screens
+Set macros for different screen sizes in `lcd.h`. By default, 16xN is enabled. 
+
+```c
+// #define LCD20xN 		// For 20xN LCDs
+#define LCD16xN			// For 16xN LCDs
+```
+
 ## 8bit example
 ```c
-#define LCD16xN // For 16xN screens
-
 Lcd_PortType ports[] = {
 	D0_GPIO_Port, D1_GPIO_Port, D2_GPIO_Port, D3_GPIO_Port,
 	D4_GPIO_Port, D5_GPIO_Port, D6_GPIO_Port, D7_GPIO_Port
@@ -35,8 +41,6 @@ Lcd_int(&lcd, -500);
 
 ## 4bit example
 ```c
-#define LCD20xN // For 20xN screens
-
 Lcd_PortType ports[] = {
 	D4_GPIO_Port, D5_GPIO_Port, D6_GPIO_Port, D7_GPIO_Port
 };


### PR DESCRIPTION
The current version of the library does not work well with screens that are not 16x02. Changes are made to the `Lcd_cursor()` function so that it works with other screen sizes. 

This was tested on STM32F4-Discovery board using LCD16x02, 16x04, and 20x04. 

Also I added `Lcd_clear()` to help clear the screen. 